### PR TITLE
Build fixes for Node.js 0.5 and 0.6

### DIFF
--- a/kyoto.js
+++ b/kyoto.js
@@ -5,7 +5,7 @@
 // possible to do all of this in the bindings, but it's easier this
 // way.
 
-var K = require('./build/default/_kyoto'),
+var K = require('./build/_kyoto'),
     LOGIC = K.PolyDB.LOGIC,
     NOREC = K.PolyDB.NOREC;
 

--- a/src/_kyoto.cc
+++ b/src/_kyoto.cc
@@ -70,11 +70,19 @@ using namespace kyotocabinet;
     return args.This();							\
   }									\
 
-#define DEFINE_EXEC(Name, Request)					\
-  static int EIO_Exec##Name(eio_req *ereq) {				\
-    Request* req = static_cast<Request *>(ereq->data);			\
-    return req->exec();							\
-  }									\
+#if NODE_VERSION_AT_LEAST(0, 5, 4)
+#define DEFINE_EXEC(Name, Request)                     \
+  static void EIO_Exec##Name(eio_req *ereq) {          \
+    Request* req = static_cast<Request *>(ereq->data); \
+    req->exec();                                       \
+  }
+#else
+#define DEFINE_EXEC(Name, Request)                     \
+  static int EIO_Exec##Name(eio_req *ereq) {           \
+    Request* req = static_cast<Request *>(ereq->data); \
+    return req->exec();                                \
+  }
+#endif
 
 #define DEFINE_AFTER(Name, Request)					\
   static int EIO_After##Name(eio_req *ereq) {				\

--- a/src/_kyoto.cc
+++ b/src/_kyoto.cc
@@ -11,6 +11,7 @@
 
 #include <v8.h>
 #include <node.h>
+#include <node_version.h>
 #include <kcpolydb.h>
 
 using namespace std;

--- a/wscript
+++ b/wscript
@@ -1,9 +1,15 @@
+import os
+
 def set_options(opt):
     opt.tool_options('compiler_cxx')
 
 def configure(conf):
     conf.check_tool('compiler_cxx')
     conf.check_tool('node_addon')
+
+def build_post(bld):
+  module_path = bld.path.find_resource('_kyoto.node').abspath(bld.env)
+  os.system('cp %r build/_kyoto.node' % module_path)
 
 def build(bld):
     obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
@@ -13,3 +19,4 @@ def build(bld):
     obj.source = 'src/_kyoto.cc'
     obj.defines = "__STDC_LIMIT_MACROS"
     obj.lib = ["kyotocabinet"]
+    bld.add_post_fun(build_post)


### PR DESCRIPTION
Due to two changes in Node 0.5.x node-kyoto won't build anymore. This patch fixes the two issues.

Tested with Node.js v0.5.10 and v0.4.12.

See https://github.com/joyent/node/commit/88afc406caa64628a249d726659b3b054f8dc70d#L7R332
and https://github.com/bnoordhuis/node-buffertools/issues/12
for more information on the two issues.
